### PR TITLE
Add instructions in README to fix OSX ssl handshake issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Windows does not require any additional packages. Everything required to run thi
 	* NOTE:
 		* In windows, the default location for storing [TPB] html files is ```C:\Users\<user>\.torrench\temp```
 
+### Osx
+
+Please note OSX requires to install package `pyopenssl`:
+
+    pip install pyopenssl
+
+
 ### Configuration instructions:
 1. Download **config.ini** from [Sync](https://ln.sync.com/dl/26cd652e0/nqzvd8b3-9gqs3pdu-32btqm2c-9r6mbymm) / [TinyUpload](http://s000.tinyupload.com/index.php?file_id=12737623922646772242)
 	* **Windows -** Copy the config file in ```C:\Users\<user>\.config\torrench\``` (create any missing directories)

--- a/torrench/utilities/Config.py
+++ b/torrench/utilities/Config.py
@@ -53,18 +53,12 @@ class Config(Common):
         self.logger.debug("getting proxies for '%s'" % (name))
         temp = []
         self.config.read(self.config_file)
-        if name == 'tpb':
-            name = 'TPB_URL'
-        elif name == 'kat':
-            name = 'KAT_URL'
-        elif name == "sky":
-            name = "SKY_URL"
-        elif name == "xbit":
-            name = "XBIT_URL"
-        elif name == "nyaa":
-            name = "NYAA_URL"
+
+        name = '{}_URL'.format(name.upper())
+
         self.url = self.config.get('Torrench-Config', name)
         self.urllist = self.url.split()
+
         if name == 'TPB_URL':
             soup = self.http_request(self.urllist[-1])
             link = soup.find_all('td', class_='site')


### PR DESCRIPTION
Ho damn, I promise to stop PR this repo after this, too much PRs for today :/

Well, on OSX when trying to look for totally legals torrents on TPB I got:

```
  File "/.../torrench/torrench/utilities/Config.py", line 64, in get_proxies
    link = soup.find_all('td', class_='site')
AttributeError: 'int' object has no attribute 'find_all'
```

It's because of [that line](https://github.com/kryptxy/torrench/blob/1e776022635fb695a0ff412ba742f04eed56e82a/torrench/utilities/Common.py#L94), the real error is:

```
requests.exceptions.SSLError: HTTPSConnectionPool(host='proxybay.one', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLError(1, '[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:600)'),))
```

And can be fixed ([has explained here](https://stackoverflow.com/questions/31649390/python-requests-ssl-handshake-failure#answer-34924131)) by installing `requests[security]` package (only for osx).

----

Ho, btw, I updated  `torrench/utilities/Config.py` to remove all these `if, elif`.