### PR TITLE
transmission-remote: add URL config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,12 @@ Additional options:
     * **(IMP)** For AUTHENTICATION - ```$TR_AUTH``` environment variable is used.
         * [TR_AUTH="username:password"]
     * **(IMP)** For PORT/SERVER - Set the PORT and SERVER variable in **[torrench.ini](https://github.com/kryptxy/torrench/blob/master/torrench.ini)** file accordingly.
+      Otherwise, you can set the URL variable, which overrides the PORT/SERVER variables.
         * If ```$TR_AUTH``` or PORT/SERVER are not set, the following (default) values are used:
         * DEFAULTS
             * Username - [None]
             * password - [None]
+            * URL - [None]
             * SERVER - localhost (127.0.0.1)
             * PORT - 9091
 

--- a/torrench/utilities/Common.py
+++ b/torrench/utilities/Common.py
@@ -538,22 +538,28 @@ class Common:
                         [TR_AUTH="username:password"]
                     2. For SERVER and PORT:
                         Set the SERVER and PORT variables in torrench.ini file.
+                        Otherwise, you can set the URL variable which overrides
+                        SERVER/PORT variables.
 
                     If None of the above are set, following default values are used:
                     DEFAULTS
                     Username - [None]
                     password - [None]
+                    URL - [None]
                     SERVER - localhost (127.0.0.1)
                     PORT - 9091
                 """
                 if client == 'transmission-remote':
-                    server = self.config.get('Torrench-Config', 'SERVER')
-                    port = self.config.get('Torrench-Config', 'PORT')
-                    if server == '':
-                        server = "localhost"
-                    if port == '':
-                        port = "9091"
-                    connect = "%s:%s" % (server, port)
+                    if self.config.has_option('Torrench-Config', 'URL'):
+                        connect = self.config.get('Torrench-Config', 'URL')
+                    else:
+                        server = self.config.get('Torrench-Config', 'SERVER')
+                        port = self.config.get('Torrench-Config', 'PORT')
+                        if server == '':
+                            server = "localhost"
+                        if port == '':
+                            port = "9091"
+                        connect = "%s:%s" % (server, port)
                     p = subprocess.Popen([client, connect, '-ne', '--add', link], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
                     e = p.communicate()  # `e` is a tuple.
                     error = e[1].decode('utf-8')


### PR DESCRIPTION
This new optional configuration variable `URL` allows the user to directly specify the URL of transmission-daemon, rather than the `SERVER`:`PORT` variables.

This solves a problem with the previous `SERVER`:`PORT` variables, wich does not permit to specify URLs like https://example.com/user/transmission when you use for example an nginx reverse proxy to access to your transmission-daemon instance via a secure SSL connection.